### PR TITLE
dd-1052162 Add Network Security Group

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -93,7 +93,7 @@
                         "name": "acceptOTNLicenseAgreement",
                         "label": "Accept OTN License Agreement",
                         "type": "Microsoft.Common.TextBox",
-                        "tooltip": "A value of N indicates you do not accept the OTN License Agreement.  In that case the deployment will fail.",
+                        "toolTip": "A value of N indicates you do not accept the OTN License Agreement.  In that case the deployment will fail.",
                         "defaultValue": "Y",
                         "visible": true,
                         "constraints": {
@@ -193,6 +193,30 @@
                         "visible": true
                     }
                 ]
+            },
+            {
+                "name": "Network",
+                "label": "Network",
+                "subLabel": {
+                    "preValidation": "Parameters to customzie network settings",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Network",
+                "elements": [
+                    {
+                        "name": "portsToExpose",
+                        "label": "Ports and port ranges to expose (N or N-N, comma separated)",
+                        "type": "Microsoft.Common.TextBox",
+                        "toolTip": "Ports and port ranges to expose (N or N-N, comma separated)",
+                        "defaultValue": "80,443,7001,7002,8000-8100",
+                        "visible": true,
+                        "constraints": {
+                            "required": true,
+                            "regex": "^((([0-9]+-[0-9]+)|([0-9]+))[,]?)+[^,]$",
+                            "validationMessage": "Only numbers, hyphen separated ranges of numbers, separated by commas"
+                        }
+                    }
+                ]
             }
         ],
         "outputs": {
@@ -204,6 +228,7 @@
             "numberOfInstances": "[int(basics('numberOfInstances'))]",
             "otnAccountPassword": "[steps('Credentials').otnAccountPassword]",
             "otnAccountUsername": "[steps('Credentials').otnAccountUsername]",
+            "portsToExpose": "[steps('Network').portsToExpose]",
             "vmSizeSelect": "[steps('VirtualMachineConfig').vmSizeSelect]",
             "wlsDomainName": "[basics('wlsDomainName')]",
             "wlsPassword": "[steps('Credentials').wlsPassword]",

--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -208,7 +208,7 @@
                         "label": "Ports and port ranges to expose (N or N-N, comma separated)",
                         "type": "Microsoft.Common.TextBox",
                         "toolTip": "Ports and port ranges to expose (N or N-N, comma separated)",
-                        "defaultValue": "80,443,7001,7002,8000-8100",
+                        "defaultValue": "80,443,7001-9000",
                         "visible": true,
                         "constraints": {
                             "required": true,

--- a/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
@@ -61,6 +61,13 @@
 				"description": "Password for your Oracle Technology Network account"
 			}
 		},
+		"portsToExpose": {
+			"type": "string",
+			"defaultValue": "80,443,7001,7002,8000-8100",
+			"metadata": {
+				"description": "Ports and port ranges to expose"
+			}
+		},
 		"wlsDomainName": {
 			"type": "string",
 			"metadata": {
@@ -168,7 +175,10 @@
 				]
 			}
 		},
-		"subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
+		"subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
+		"networkSecurityGroupName": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
+		"networkSecurityGroupRef": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
+		"appGatewayPortrange": ",65200-65535"
 	},
 	"resources": [
 		{
@@ -183,6 +193,29 @@
 					"resources": [
 					]
 				}
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups",
+			"apiVersion": "2019-06-01",
+			"name": "[variables('networkSecurityGroupName')]",
+			"location": "[parameters('location')]",
+			"properties": {
+				"securityRules": [
+					{
+						"name": "TCP",
+						"properties": {
+							"protocol": "TCP",
+							"sourcePortRange": "*",
+							"sourceAddressPrefix": "*",
+							"destinationAddressPrefix": "*",
+							"access": "Allow",
+							"priority": 320,
+							"direction": "Inbound",
+							"destinationPortRanges": "[split(concat(parameters('portsToExpose'),variables('appGatewayPortrange')), ',')]"
+						}
+					}
+				]
 			}
 		},
 		{
@@ -218,6 +251,9 @@
 			"apiVersion": "2018-11-01",
 			"name": "[variables('virtualNetworkName')]",
 			"location": "[parameters('location')]",
+			"dependsOn": [
+				"[variables('networkSecurityGroupRef')]"
+			],
 			"properties": {
 				"addressSpace": {
 					"addressPrefixes": [
@@ -228,7 +264,10 @@
 					{
 						"name": "[variables('subnetName')]",
 						"properties": {
-							"addressPrefix": "[variables('subnetPrefix')]"
+							"addressPrefix": "[variables('subnetPrefix')]",
+							"networkSecurityGroup": {
+								"id": "[variables('networkSecurityGroupRef')]"
+							}
 						}
 					}
 				]

--- a/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
@@ -63,7 +63,7 @@
 		},
 		"portsToExpose": {
 			"type": "string",
-			"defaultValue": "80,443,7001,7002,8000-8100",
+			"defaultValue": "80,443,7001-9000",
 			"metadata": {
 				"description": "Ports and port ranges to expose"
 			}
@@ -178,7 +178,7 @@
 		"subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
 		"networkSecurityGroupName": "[concat(parameters('dnsLabelPrefix'), '-nsg')]",
 		"networkSecurityGroupRef": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
-		"appGatewayPortrange": ",65200-65535"
+		"requiredPortrange": ",65200-65535,5556"
 	},
 	"resources": [
 		{
@@ -212,7 +212,7 @@
 							"access": "Allow",
 							"priority": 320,
 							"direction": "Inbound",
-							"destinationPortRanges": "[split(concat(parameters('portsToExpose'),variables('appGatewayPortrange')), ',')]"
+							"destinationPortRanges": "[split(concat(parameters('portsToExpose'),variables('requiredPortrange')), ',')]"
 						}
 					}
 				]

--- a/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
@@ -155,7 +155,7 @@
 		"publicIPAddressType": "Dynamic",
 		"vmSize": "[parameters('vmSizeSelect')]",
 		"virtualNetworkName": "[concat(parameters('wlsDomainName'),'_VNET')]",
-                "oradownScript": "oradown.sh",
+		"oradownScript": "oradown.sh",
 		"ScriptFileName": "setupClusterDomain.sh",
 		"linuxConfiguration": {
 			"disablePasswordAuthentication": true,
@@ -180,7 +180,8 @@
 				"template": {
 					"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 					"contentVersion": "1.0.0.0",
-					"resources": []
+					"resources": [
+					]
 				}
 			}
 		},
@@ -193,7 +194,8 @@
 				"name": "[variables('storageAccountType')]"
 			},
 			"kind": "Storage",
-			"properties": {}
+			"properties": {
+			}
 		},
 		{
 			"type": "Microsoft.Network/publicIPAddresses",
@@ -207,7 +209,7 @@
 			"properties": {
 				"publicIPAllocationMethod": "[variables('publicIPAddressType')]",
 				"dnsSettings": {
-				        "domainNameLabel": "[concat(toLower(parameters('dnsLabelPrefix')),copyindex(),'-',take(replace(parameters('guidValue'),'-',''),10),'-',toLower(parameters('wlsDomainName')))]"
+					"domainNameLabel": "[concat(toLower(parameters('dnsLabelPrefix')),copyindex(),'-',take(replace(parameters('guidValue'),'-',''),10),'-',toLower(parameters('wlsDomainName')))]"
 				}
 			}
 		},


### PR DESCRIPTION
Thanks to Jianguo Ma @majguo, I know that the absence of an NSG from this template caused Azure to
apply an auto-generated one.  This one is too strong.

By creating our own, we can prevent the network problems that prevent access.

There is one additional step that must be performed after deployment to the Oracle Enterprise Java 
subscription, however.

* Security rules to delete.

   * 103 NRMS-Rule-103
   
   * 105 NRMS-Rule-105