### PR TITLE
Added verify wls services to CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ env:
   wlsDomainName : clusterDomain
   wlsUserName : weblogic
   managedServerPrefix : managedServer
+  managedServerVM: "managedServerVM1"
   numberOfInstances : 2
   adminVMName: adminServerVM
   managedServers: "managedServer1"
@@ -26,6 +27,8 @@ env:
   ref_javaee: 6807e2ae3e8a8492edf211b9f4f0b7ed3a2a29e7
   ref_armttk: e2fbdcb93a4b2004c9ea953956b85248e0ef8c1c 
   git_token: ${{ secrets.GIT_TOKEN }} 
+  wls_admin_services : "rngd wls_admin wls_nodemanager"
+  wls_managedServer_services : "rngd wls_nodemanager"
 
 jobs:
   preflight:
@@ -300,6 +303,20 @@ jobs:
             echo "VM Public IP ${publicIp}"
             echo "##[set-env name=wlsPublicIP;]${publicIP}"  
 
+      - name: Query public IP of managedServerVM1
+        id: query-wls-managed-ip
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            echo "query public ip"
+            publicIP=$(az vm show \
+              --resource-group $resourceGroup \
+              --name $managedServerVM -d \
+              --query publicIps -o tsv)
+            echo "VM Public IP ${publicIp}"
+            echo "##[set-env name=ms1PublicIP;]${publicIP}"  
+
       - name: Verify WebLogic Server Installation
         id: verify-wls
         run: |
@@ -307,7 +324,19 @@ jobs:
           echo "Verifying Weblgic server installation"
           timeout 6m sh -c 'until nc -zv $0 $1; do echo "nc rc: $?"; sleep 5; done' ${wlsPublicIP} 22
           sshpass -p ${wlsPassword} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt weblogic@${wlsPublicIP} 'bash -s' < arm-oraclelinux-wls-cluster/test/scripts/verify-wls-path.sh
-          
+
+      - name: Verify wls admin services
+        id: veriy-admin-service
+        run: |
+          echo "Verifying WebLogic services at admin server"
+          sshpass -p ${wlsPassword} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt weblogic@${wlsPublicIP} 'bash -s' < arm-oraclelinux-wls-cluster/test/scripts/verify-services.sh $wls_admin_services          
+
+      - name: Verify wls managed server services
+        id: veriy-msservice
+        run: |
+          echo "Verifying WebLogic services at managed server"
+          sshpass -p ${wlsPassword} -v ssh -p 22 -o StrictHostKeyChecking=no -o ConnectTimeout=100 -v -tt weblogic@${ms1PublicIP} 'bash -s' < arm-oraclelinux-wls-cluster/test/scripts/verify-services.sh $wls_managedServer_services
+
       - name: Verify WebLogic Server Access
         id: verify-wls-access
         run: |

--- a/test/scripts/verify-services.sh
+++ b/test/scripts/verify-services.sh
@@ -1,0 +1,38 @@
+# Verify the service using systemctl status
+function verifyServiceStatus()
+{
+  serviceName=$1
+  systemctl status rngd | grep "active (running)"    
+  if [[ $? != 0 ]]; then
+     echo "$serviceName is not in active (running) state"
+     exit 1
+  fi
+  echo "$serviceName is active (running)"
+}
+
+#Verify the service using systemctl is-active
+function verifyServiceActive()
+{
+  serviceName=$1
+  state=$(systemctl is-active $serviceName)
+  if [[ $state == "active" ]]; then
+     echo "$serviceName is active"
+  else
+     echo "$serviceName is not active"
+     exit 1
+  fi
+}
+
+# Pass the services to be checked based on admin/managed servers
+# For admin server    : rngd wls_admin wls_nodemanager
+# For managed server  : rngd wls_nodemanager
+
+export servicesList=$*
+
+for service in $servicesList
+do
+   verifyServiceStatus $service
+   verifyServiceActive $service
+done
+
+exit 0


### PR DESCRIPTION
Added verify-services verification as part of CI/CD.
Scenario covers verifying whether following services are available and running.

- admin server VM 
  Verifies whether rngd, wls_admin and wls_nodemanager services are running and active

- managed server VM
  Verifies whether rngd and wls_nodemanager services are running and active

Refer trial run https://github.com/sanjaymantoor/arm-oraclelinux-wls-cluster/actions/runs/145927688