### PR TITLE
Reverted lines that cause this failure in the version of ARM TTK currently in use.

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -292,7 +292,7 @@
                         "toolTip": "Use only letters and numbers",
                         "constraints": {
                             "required": true,
-                            "regex": "^[a-z0-9A-Z\\.\\-\\_()]{0,89}([a-z0-9A-Z\\-\\_()]{1})$",
+                            "regex": "^[a-z0-9A-Z]{1,30}$",
                             "validationMessage": "[if(greater(length(steps('section_appGateway').keyVaultResourceGroup), 90),'Resource group names only allow up to 90 characters.', 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens and parenthesis and cannot end in a period.')]"
                         },
                         "visible": "[steps('section_appGateway').enableAppGateway]"
@@ -305,7 +305,7 @@
                         "toolTip": "Use only letters and numbers",
                         "constraints": {
                             "required": true,
-                            "regex": "^(?=.{3,24}$)[a-zA-Z](([a-z0-9A-Z]*|(?:\\-[^\\-][a-z0-9A-Z]*))*)$",
+                            "regex": "^[a-z0-9A-Z]{1,30}$",
                             "validationMessage": "[if(or(greater(length(steps('section_appGateway').keyVaultName), 24), less(length(steps('section_appGateway').keyVaultName), 3)),'Vault name must be between 3-24 alphanumeric characters. The name must begin with a letter, end with a letter or digit, and not contain consecutive hyphens.','Vault name must only contain alphanumeric characters and dashes and cannot start with a number')]"
                         },
                         "visible": "[steps('section_appGateway').enableAppGateway]"


### PR DESCRIPTION
modified:   arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json

Reverted lines that cause this failure in the version of ARM TTK currently in use.

    [-] Textboxes Are Well Formed (160 ms)

Something about this regex causes the test to fail.

"regex": "^[a-z0-9A-Z\\.\\-\\_()]{0,89}([a-z0-9A-Z\\-\\_()]{1})$",

It might be time for us to fix https://github.com/wls-eng/arm-oraclelinux-wls/issues/118 ?