### PR TITLE
Updated admin, nodemanager service and service verification

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/scripts/setupClusterDomain.sh
+++ b/arm-oraclelinux-wls-cluster/src/main/scripts/setupClusterDomain.sh
@@ -302,6 +302,7 @@ function create_nodemanager_service()
  fi
  sudo chown -R $username:$groupname $DOMAIN_PATH/$wlsDomainName/nodemanager/nodemanager.properties*
  echo "Creating NodeManager service"
+ # Added waiting for network-online service and restart service 
  cat <<EOF >/etc/systemd/system/wls_nodemanager.service
  [Unit]
 Description=WebLogic nodemanager service
@@ -330,6 +331,7 @@ EOF
 # This function to create adminserver service
 function create_adminserver_service()
 {
+# Added waiting for network-online service and restart service   
  echo "Creating admin server service"
  cat <<EOF >/etc/systemd/system/wls_admin.service
 [Unit]

--- a/test/scripts/verify-services.sh
+++ b/test/scripts/verify-services.sh
@@ -2,7 +2,7 @@
 function verifyServiceStatus()
 {
   serviceName=$1
-  systemctl status rngd | grep "active (running)"    
+  systemctl status $serviceName | grep "active (running)"     
   if [[ $? != 0 ]]; then
      echo "$serviceName is not in active (running) state"
      exit 1


### PR DESCRIPTION
Updated wls_admin and wls_nodemanager service
Corrected service verification command

This is fix for [#issue160: CI/CD test scenarios failing intermittently due to nodemanager service failure ](https://github.com/wls-eng/arm-oraclelinux-wls/issues/160)

CI/CD after changes found working fine.
Refer https://github.com/sanjaymantoor/arm-oraclelinux-wls-cluster/actions/runs/228272166