### PR TITLE
Adding NSG rules for NodeManager and Admin channel port

### DIFF
--- a/addnsgrule/src/main/arm/mainTemplate.json
+++ b/addnsgrule/src/main/arm/mainTemplate.json
@@ -1,0 +1,139 @@
+{
+	"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+	"contentVersion": "1.0.0.0",
+	"parameters": {
+		"location": {
+			"type": "string",
+			"metadata": {
+				"description": "Location for all resources."
+			}
+		},
+		"name_networkSecurityGroup": {
+			"type": "string",
+			"metadata": {
+				"description": "Network Security Group name"
+			}
+		},
+		"const_subnetPrefix": {
+			"type": "string",
+			"defaultValue": "10.0.0.0/24"			
+		}
+	},
+	"variables": {
+		"const_requiredAppGatewayPortrange": "65200-65535"
+	},
+	"resources": [
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('name_networkSecurityGroup'),'/','AppgatewayPorts')]",
+			"apiVersion": "2018-08-01",
+			"properties": {
+			  "protocol": "TCP",
+			  "sourcePortRange": "*",
+			  "sourceAddressPrefix": "GatewayManager",
+			  "destinationAddressPrefix": "*",
+			  "access": "Allow",
+			  "priority": 200,
+			  "direction": "Inbound",
+			  "destinationPortRanges": "[split(variables('const_requiredAppGatewayPortrange'), ',')]"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('name_networkSecurityGroup'),'/','WebLogicAdminPortsAllowed')]",
+			"apiVersion": "2018-08-01",
+			"properties": {
+			  "protocol": "TCP",
+			  "sourcePortRange": "*",
+			  "destinationAddressPrefix": "*",
+			  "access": "Allow",
+			  "priority": 210,
+			  "direction": "Inbound",
+			  "destinationPortRanges": [
+				"7001",
+				"7002"
+			  ],
+			 "sourceAddressPrefix": "[parameters('const_subnetPrefix')]"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('name_networkSecurityGroup'),'/','WebLogicAdminPortsDenied')]",
+			"apiVersion": "2018-08-01",
+			"properties": {
+			  "protocol": "*",
+			  "sourcePortRange": "*",
+			  "destinationAddressPrefix": "*",
+			  "access": "Deny",
+			  "priority": 211,
+			  "direction": "Inbound",
+			  "destinationPortRanges": [
+				"7001",
+				"7002"
+			  ],
+			 "sourceAddressPrefix": "Internet"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('name_networkSecurityGroup'),'/','WebLogiManagedPortsAllowed')]",
+			"apiVersion": "2018-08-01",
+			"properties": {
+			  "protocol": "*",
+			  "sourcePortRange": "*",
+			  "destinationAddressPrefix": "*",
+			  "access": "Deny",
+			  "priority": 220,
+			  "direction": "Inbound",
+			  "destinationPortRanges": [
+				"8001"
+			  ],
+			 "sourceAddressPrefix": "[parameters('const_subnetPrefix')]"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('name_networkSecurityGroup'),'/','WebLogiManagedPortsDenied')]",
+			"apiVersion": "2018-08-01",
+			"properties": {
+			  "protocol": "*",
+			  "sourcePortRange": "*",
+			  "destinationAddressPrefix": "*",
+			  "access": "Deny",
+			  "priority": 221,
+			  "direction": "Inbound",
+			  "destinationPortRanges": [
+				"8001"
+			  ],
+			 "sourceAddressPrefix": "Internet"
+			}
+		},
+		{
+			"type": "Microsoft.Network/networkSecurityGroups/securityRules",
+			"name": "[concat(parameters('name_networkSecurityGroup'),'/','WebLogiManagedChannelPortsDenied')]",
+			"apiVersion": "2018-08-01",
+			"properties": {
+			  "protocol": "*",
+			  "sourcePortRange": "*",
+			  "destinationAddressPrefix": "*",
+			  "access": "Deny",
+			  "priority": 230,
+			  "direction": "Inbound",
+			  "destinationPortRanges": [
+				"8501"
+			  ],
+			 "sourceAddressPrefix": "Internet"
+			}
+		}
+	],
+	"outputs": {
+		"nsg": {
+			"type": "string",
+			"value": "[resourceId('Microsoft.Network/networkSecurityGroups').name]"
+		},
+		"subnet" : {
+			"type": "string",
+			"value": "[resourceId('Microsoft.Network/virtualNetworks').name]"
+		}
+	}
+}

--- a/addnsgrule/src/main/arm/mainTemplate.json
+++ b/addnsgrule/src/main/arm/mainTemplate.json
@@ -125,15 +125,5 @@
 			 "sourceAddressPrefix": "Internet"
 			}
 		}
-	],
-	"outputs": {
-		"nsg": {
-			"type": "string",
-			"value": "[resourceId('Microsoft.Network/networkSecurityGroups').name]"
-		},
-		"subnet" : {
-			"type": "string",
-			"value": "[resourceId('Microsoft.Network/virtualNetworks').name]"
-		}
-	}
+	]
 }

--- a/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -218,6 +218,32 @@
                             "direction": "Inbound",
                             "destinationPortRanges": "[split(concat(parameters('portsToExpose'),variables('const_requiredPortrange')), ',')]"
                         }
+                    },
+                    {
+                        "name": "WebLogicNMPort",
+                        "properties": {
+                            "protocol": "TCP",
+                            "sourcePortRange": "*",
+                            "sourceAddressPrefix": "Internet",
+                            "destinationAddressPrefix": "*",
+                            "access": "Deny",
+                            "priority": 201,
+                            "direction": "Inbound",
+                            "destinationPortRanges": [ "5556" ]
+                        }
+                    },
+                    {
+                        "name": "WebLogicAdminChannelPort",
+                        "properties": {
+                            "protocol": "TCP",
+                            "sourcePortRange": "*",
+                            "sourceAddressPrefix": "Internet",
+                            "destinationAddressPrefix": "*",
+                            "access": "Deny",
+                            "priority": 202,
+                            "direction": "Inbound",
+                            "destinationPortRanges": [ "7005" ]
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
This is first part of NSG rules implementation for the  [Issue #58 Cluster Offers: Worker Nodes: make public/private IP configurable](https://github.com/wls-eng/arm-oraclelinux-wls/issues/58)

As part of this implementation WebLogic NodeManager and WebLogic Admin server channel ports , by default public access is denied.