### PR TITLE
Enhance ELK memory requirement validation message.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ env:
   managedServers: "managedServer1"
   nsg: wls-nsg
   numberOfInstances: 2
-  refArmttk: 1b58e01c5f201a819d795dbc3576c2fd7cbed821
+  refArmttk: 8e08a92dbb0a22b8560ec854a60e9a8a7b71c68f
   refJavaee: 6807e2ae3e8a8492edf211b9f4f0b7ed3a2a29e7
   resourceGroupForDependency: wlsd-${{ github.run_id }}-${{ github.run_number }}
   resourceGroupPrefix: ${{ github.run_id }}-${{ github.run_number }}

--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -689,8 +689,8 @@
                                 "name": "elkMemoryRequired",
                                 "type": "Microsoft.Common.InfoBox",
                                 "options": {
-                                    "icon": "Warning",
-                                    "text": "Please make sure the selected Virtual Machines have more than 2.5GB memory to set up Elasticsearch and Kibana."
+                                    "icon": "Error",
+                                    "text": "Your selected Virtual Machines have less than 2.5GB memory to set up Elasticsearch and Kibana, please go to Basics -> Virtual machine size to change it, recommended size is Standard_A2_v2."
                                 },
                                 "visible": "[and(contains('Standard_A1,Basic_A1,Standard_B1ms,Standard_A1_v2,Standard_F1,Standard_F1s', basics('vmSizeSelect')),bool(steps('section_elk').enableELK))]"
                             },
@@ -701,10 +701,17 @@
                                 "toolTip": "Elasticsearch URI. Used as REST API rui to send logs to Elasticsearch.",
                                 "constraints": {
                                     "required": true,
-                                    "regex": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)",
-                                    "validationMessage": "The value must be a valid uri."
-                                },
-                                "required": true
+                                    "validations": [
+                                        {
+                                            "regex": "^https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)$",
+                                            "message": "The value must be a valid uri."
+                                        },
+                                        {
+                                            "isValid": "[not(contains('Standard_A1,Basic_A1,Standard_B1ms,Standard_A1_v2,Standard_F1,Standard_F1s', basics('vmSizeSelect')))]",
+                                            "message": "Your selected Virtual Machines have less than 2.5GB memory to set up Elasticsearch and Kibana, please go to Basics -> Virtual machine size to change it, recommended size is Standard_A2_v2."
+                                        }
+                                    ]
+                                }
                             },
                             {
                                 "name": "elasticsearchPort",
@@ -715,8 +722,7 @@
                                     "required": true,
                                     "regex": "^[0-9]+$",
                                     "validationMessage": "The value must be a valid port."
-                                },
-                                "required": true
+                                }
                             },
                             {
                                 "name": "elasticsearchUserName",
@@ -727,8 +733,7 @@
                                     "required": true,
                                     "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])",
                                     "validationMessage": "The value must be valid Elasticsearch user name."
-                                },
-                                "required": true
+                                }
                             },
                             {
                                 "name": "elasticsearchPassword",
@@ -740,8 +745,7 @@
                                 "toolTip": "The credential (usually a password) used to connect to the LDAP server.",
                                 "constraints": {
                                     "required": true
-                                },
-                                "required": true
+                                }
                             },
                             {
                                 "name": "logsToIntegrate",


### PR DESCRIPTION
modified: arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
Set the message level to Error.
Add validation rule to elasticsearchURI TextBox to block ELK deployment with invalid memory options.
Remove redundant `required` properties.

This PR will cause template validation failure, as I applied latest schema of TextBox. while latest arm-ttk does not support the schema.
I have created  issue [Support UIDefinition.TextBox.constraints.validations](https://github.com/Azure/arm-ttk/issues/208),
and created PR for that issue: https://github.com/Azure/arm-ttk/pull/209

[TBD]
1. wait for the [arm-ttk-pr-209](https://github.com/Azure/arm-ttk/pull/209) approved.
2. update arm-ttk reference in build.yaml