### PR TITLE
Updated to support latest base images

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -8,29 +8,29 @@
                 "name": "skuUrnVersion",
                 "type": "Microsoft.Common.DropDown",
                 "label": "Oracle WebLogic Image",
-                "defaultValue": "WebLogic Server 12.2.1.3.0 and JDK8u131 on Oracle Linux 7.4",
+                "defaultValue": "WebLogic Server 14.1.1.0.0 and JDK11 on Oracle Linux 7.6",
                 "toolTip": "Choose Oracle WebLogic image, which is provided by Oracle, with Java and WebLogic preinstalled.",
                 "constraints": {
                     "allowedValues": [
                         {
-                            "label": "WebLogic Server 12.2.1.3.0 and JDK8u131 on Oracle Linux 7.4",
-                            "value": "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1"
+                            "label": "WebLogic Server 12.2.1.3.0 and JDK8 on Oracle Linux 7.4",
+                            "value": "owls-122130-jdk8-ol74;Oracle:weblogic-122130-jdk8-ol74:owls-122130-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 12.2.1.3.0 and JDK8u131 on Oracle Linux 7.3",
-                            "value": "owls-122130-8u131-ol73;Oracle:weblogic-122130-jdk8u131-ol73:owls-122130-8u131-ol7;1.1.6"
+                            "label": "WebLogic Server 12.2.1.3.0 and JDK8 on Oracle Linux 7.3",
+                            "value": "owls-122130-jdk8-ol73;Oracle:weblogic-122130-jdk8-ol73:owls-122130-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 12.2.1.4.0 and JDK8u251 on Oracle Linux 7.6",
-                            "value": "owls-122140-8u251-ol76;Oracle:weblogic-122140-jdk8u251-ol76:owls-122140-8u251-ol7;1.1.1"
+                            "label": "WebLogic Server 12.2.1.4.0 and JDK8 on Oracle Linux 7.6",
+                            "value": "owls-122140-jdk8-ol76;Oracle:weblogic-122140-jdk8-ol76:owls-122140-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK8u251 on Oracle Linux 7.6",
-                            "value": "owls-141100-8u251-ol76;Oracle:weblogic-141100-jdk8u251-ol76:owls-141100-8u251-ol7;1.1.1"
+                            "label": "WebLogic Server 14.1.1.0.0 and JDK8 on Oracle Linux 7.6",
+                            "value": "owls-141100-jdk8-ol76;Oracle:weblogic-141100-jdk8-ol76:owls-141100-jdk8-ol7;latest"
                         },
                         {
-                            "label": "WebLogic Server 14.1.1.0.0 and JDK11_07 on Oracle Linux 7.6",
-                            "value": "owls-141100-11_07-ol76;Oracle:weblogic-141100-jdk11_07-ol76:owls-141100-11_07-ol7;1.1.1"
+                            "label": "WebLogic Server 14.1.1.0.0 and JDK11 on Oracle Linux 7.6",
+                            "value": "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest"
                         }
                     ],
                     "required": true

--- a/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
@@ -191,13 +191,13 @@
         },
         "skuUrnVersion": {
            "type": "string",
-           "defaultValue": "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1",
+           "defaultValue": "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest",
            "allowedValues": [
-              "owls-122130-8u131-ol73;Oracle:weblogic-122130-jdk8u131-ol73:owls-122130-8u131-ol7;1.1.6",
-              "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1",
-              "owls-122140-8u251-ol76;Oracle:weblogic-122140-jdk8u251-ol76:owls-122140-8u251-ol7;1.1.1",
-              "owls-141100-8u251-ol76;Oracle:weblogic-141100-jdk8u251-ol76:owls-141100-8u251-ol7;1.1.1",
-              "owls-141100-11_07-ol76;Oracle:weblogic-141100-jdk11_07-ol76:owls-141100-11_07-ol7;1.1.1"
+              "owls-122130-jdk8-ol73;Oracle:weblogic-122130-jdk8-ol73:owls-122130-jdk8-ol7;latest",
+              "owls-122130-jdk8-ol74;Oracle:weblogic-122130-jdk8-ol74:owls-122130-jdk8-ol7;latest",
+              "owls-122140-jdk8-ol76;Oracle:weblogic-122140-jdk8-ol76:owls-122140-jdk8-ol7;latest",
+              "owls-141100-jdk8-ol76;Oracle:weblogic-141100-jdk8-ol76:owls-141100-jdk8-ol7;latest",
+              "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest"
            ],
            "metadata": {
               "description": "The Oracle Linux image with Weblogic and Java preinstalled. Semicolon separated string of Sku, URN, and Version"

--- a/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -115,13 +115,13 @@
         },
         "skuUrnVersion": {
            "type": "string",
-           "defaultValue": "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1",
+           "defaultValue": "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest",
            "allowedValues": [
-              "owls-122130-8u131-ol73;Oracle:weblogic-122130-jdk8u131-ol73:owls-122130-8u131-ol7;1.1.6",
-              "owls-122130-8u131-ol74;Oracle:weblogic-122130-jdk8u131-ol74:owls-122130-8u131-ol7;1.1.1",
-              "owls-122140-8u251-ol76;Oracle:weblogic-122140-jdk8u251-ol76:owls-122140-8u251-ol7;1.1.1",
-              "owls-141100-8u251-ol76;Oracle:weblogic-141100-jdk8u251-ol76:owls-141100-8u251-ol7;1.1.1",
-              "owls-141100-11_07-ol76;Oracle:weblogic-141100-jdk11_07-ol76:owls-141100-11_07-ol7;1.1.1"
+              "owls-122130-jdk8-ol73;Oracle:weblogic-122130-jdk8-ol73:owls-122130-jdk8-ol7;latest",
+              "owls-122130-jdk8-ol74;Oracle:weblogic-122130-jdk8-ol74:owls-122130-jdk8-ol7;latest",
+              "owls-122140-jdk8-ol76;Oracle:weblogic-122140-jdk8-ol76:owls-122140-jdk8-ol7;latest",
+              "owls-141100-jdk8-ol76;Oracle:weblogic-141100-jdk8-ol76:owls-141100-jdk8-ol7;latest",
+              "owls-141100-jdk11-ol76;Oracle:weblogic-141100-jdk11-ol76:owls-141100-jdk11-ol7;latest"
            ],
            "metadata": {
               "description": "The Oracle Linux image with Weblogic and Java preinstalled. Semicolon separated string of Sku, URN, and Version"
@@ -171,7 +171,7 @@
         "const_addressPrefix": "10.0.0.0/16",
         "const_appGatewaySubnetPrefix": "10.0.1.0/24",
         "const_hyphen": "-",
-        "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),'jdk',split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
+        "const_imageOffer": "[concat('weblogic',variables('const_hyphen'), split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[1],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[2],variables('const_hyphen'),split(variables('name_linuxImageOfferSKU'),variables('const_hyphen'))[3],if(parameters('usePreviewImage'),'-preview',''))]",
         "const_imagePublisher": "oracle",
         "const_linuxConfiguration": {
             "disablePasswordAuthentication": true,
@@ -525,9 +525,9 @@
         },
         {
             "apiVersion": "2019-10-01",
-            "name": "${from.owls-122130-8u131-ol74}",
+            "name": "${from.owls-122130-jdk8-ol74}",
             "type": "Microsoft.Resources/deployments",
-            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122130-8u131-ol74'), bool('true'), bool('false'))]",
+            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-122130-jdk8-ol74'), bool('true'), bool('false'))]",
             "dependsOn": [
                 "virtualMachineExtensionLoop"
             ],
@@ -543,9 +543,9 @@
         },
         {
             "apiVersion": "2019-10-01",
-            "name": "${from.owls-122130-8u131-ol73}",
+            "name": "${from.owls-122130-jdk8-ol73}",
             "type": "Microsoft.Resources/deployments",
-            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122130-8u131-ol73'), bool('true'), bool('false'))]",
+            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122130-jdk8-ol73'), bool('true'), bool('false'))]",
             "dependsOn": [
                 "virtualMachineExtensionLoop"
             ],
@@ -561,9 +561,9 @@
         },
         {
             "apiVersion": "2019-10-01",
-            "name": "${from.owls-122140-8u251-ol76}",
+            "name": "${from.owls-122140-jdk8-ol76}",
             "type": "Microsoft.Resources/deployments",
-            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122140-8u251-ol76'), bool('true'), bool('false'))]",
+            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'from.owls-122140-jdk8-ol76'), bool('true'), bool('false'))]",
             "dependsOn": [
                 "virtualMachineExtensionLoop"
             ],
@@ -579,9 +579,9 @@
         },
         {
             "apiVersion": "2019-10-01",
-            "name": "${from.owls-141100-8u251-ol76}",
+            "name": "${from.owls-141100-jdk8-ol76}",
             "type": "Microsoft.Resources/deployments",
-            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-8u251-ol76'), bool('true'), bool('false'))]",
+            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk8-ol76'), bool('true'), bool('false'))]",
             "dependsOn": [
                 "virtualMachineExtensionLoop"
             ],
@@ -597,9 +597,9 @@
         },
         {
             "apiVersion": "2019-10-01",
-            "name": "${from.owls-141100-11_07-ol76}",
+            "name": "${from.owls-141100-jdk11-ol76}",
             "type": "Microsoft.Resources/deployments",
-            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-11_07-ol76'), bool('true'), bool('false'))]",
+            "condition": "[if(contains(variables('name_linuxImageOfferSKU'), 'owls-141100-jdk11-ol76'), bool('true'), bool('false'))]",
             "dependsOn": [
                 "virtualMachineExtensionLoop"
             ],


### PR DESCRIPTION
Updated offers to use new base images.

Changes are tested by manually doing azure deployment with latest skuUrnVersion.
Updated default value for skuUrnVersion to "WebLogic Server 14.1.1.0.0 and JDK11 on Oracle Linux 7.6"
