### PR TITLE
Validate ELK connection info && enhance Coherence node manager service

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/scripts/elkIntegration.sh
+++ b/arm-oraclelinux-wls-cluster/src/main/scripts/elkIntegration.sh
@@ -672,12 +672,47 @@ function cleanup() {
     echo "Cleanup completed."
 }
 
-function createTempFolder()
+function create_temp_folder()
 {
     export SCRIPT_PATH="/u01/tmp"
     sudo rm -f -r ${SCRIPT_PATH}
     sudo mkdir ${SCRIPT_PATH}
     sudo rm -rf $SCRIPT_PATH/*
+}
+
+function validate_elastic_server()
+{
+    timestamp=$(date +%s)
+    testIndex="azure-weblogic-validate-elastic-server-${timestamp}"
+    output=$(curl -XPUT --user ${elasticUserName}:${elasticPassword}  ${elasticURI}/${testIndex})
+    if [[ $? -eq 1 ||  -z `echo $output | grep "\"acknowledged\":true"` ]];then
+        echo $output
+        exit 1
+    fi
+
+    count=1
+    status404="\"status\":404"
+    while [[ -n ${status404} ]]; do
+        echo "."
+        count=$((count + 1))
+        # remove the test index
+        echo "Removing test index..."
+        curl -XDELETE --user ${elasticUserName}:${elasticPassword}  ${elasticURI}/${testIndex}
+        echo "Checking if test index is removed."
+        status404=$(curl -XGET --user ${elasticUserName}:${elasticPassword}  ${elasticURI}/${testIndex} | grep "\"status\":404")
+        echo ${status404}
+        if [[ -n ${status404} ]]; then
+            echo "Test index is removed..."
+            break
+        fi
+
+        if [ $count -le 30 ]; then
+            sleep 1m
+        else
+            echo "Error : Maximum attempts exceeded while removing test index from elastic server"
+            exit 1
+        fi
+    done
 }
 
 # main script starts from here
@@ -719,8 +754,9 @@ if [ $# -ne 14 ]; then
     exit 1
 fi
 
-createTempFolder
+create_temp_folder
 validate_input
+validate_elastic_server
 
 echo "start to configure ELK"
 setup_javahome

--- a/arm-oraclelinux-wls-cluster/src/main/scripts/setupCoherence.sh
+++ b/arm-oraclelinux-wls-cluster/src/main/scripts/setupCoherence.sh
@@ -276,9 +276,12 @@ function createNodeManagerService() {
     fi
     sudo chown -R $username:$groupname $wlsDomainPath/$wlsDomainName/nodemanager/nodemanager.properties*
     echo "Creating NodeManager service"
+    # Added waiting for network-online service and restart service
     cat <<EOF >/etc/systemd/system/wls_nodemanager.service
- [Unit]
+[Unit]
 Description=WebLogic nodemanager service
+After=network-online.target
+Wants=network-online.target
  
 [Service]
 Type=simple
@@ -291,6 +294,8 @@ User=oracle
 Group=oracle
 KillMode=process
 LimitNOFILE=65535
+Restart=always
+RestartSec=3
  
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Logstash will not fail or fire error message if the elastic server connection is incorrect.

We have to validate accessibility of elastic server before starting Logstash.

Steps to validate the server connection:

1. Create test index
`curl -XPUT --user ${elasticUserName}:${elasticPassword}  ${elasticURI}/${testIndex}`
2. Remove the test index
`curl -XDELETE --user ${elasticUserName}:${elasticPassword}  ${elasticURI}/${testIndex}`
3. Check if the test index still exists
`curl -XGET --user ${elasticUserName}:${elasticPassword}  ${elasticURI}/${testIndex}`