### PR TITLE
Add system assigned managed idendity for vm and ELK index clean up

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -680,7 +680,8 @@ jobs:
             ${{ env.wlsPassword }} \
             ${{ env.userName }} \
             ${{ env.testbranchName }} \
-            ${{ env.managedServerPrefix }}
+            ${{ env.managedServerPrefix }} \
+            ${{ github.run_id }}${{ github.run_number }}
 
             echo "Deploy ELK Template..."
             az group deployment create \
@@ -891,6 +892,10 @@ jobs:
           inlineScript: |
             echo "delete... " $resourceGroup
             az group delete --yes --no-wait --verbose --name $resourceGroup
+      - name: Delete ELK index
+        id: delete-elk-index
+        run: |
+          curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-cluster-${{ github.run_id }}${{ github.run_number }}
 
   cleanup:
     needs: deploy-weblogic-cluster

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ on:
       - develop
   schedule:
     - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      enableELK:
+        description: 'Specify whether to enable ELK depoyment or not.'
+        required: true
+        default: 'false'
   repository_dispatch:
 
 env:
@@ -662,6 +668,7 @@ jobs:
 
       - name: Set up ELK by deploying sub template
         id: enable-elk
+        if: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.enableELK == 'true'}}
         uses: azure/CLI@v1
         with:
           azcliversion: ${{ env.azCliVersion }}
@@ -894,6 +901,7 @@ jobs:
             az group delete --yes --no-wait --verbose --name $resourceGroup
       - name: Delete ELK index
         id: delete-elk-index
+        if: ${{github.event_name == 'workflow_dispatch' && github.event.inputs.enableELK == 'true'}}
         run: |
           curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-cluster-${{ github.run_id }}${{ github.run_number }}
 

--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -251,6 +251,27 @@
                         "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
                     },
                     {
+                        "name": "useSystemAssignedManagedIdentity",
+                        "label": "Cause a system assigned managed identity to be created for the VM(s).",
+                        "type": "Microsoft.Common.OptionsGroup",
+                        "toolTip": "System assigned managed identities enable credential-free secure access to many Azure resources from this VM.",
+                        "constraints": {
+                            "allowedValues": [
+                                {
+                                    "label": "Yes",
+                                    "value": true
+                                },
+                                {
+                                    "label": "No",
+                                    "value": false
+                                }
+                            ],
+                            "required": true
+                        },
+                        "defaultValue": "Yes",
+                        "visible": "[bool(basics('basicsOptional').basicsOptionalAcceptDefaults)]"
+                    }, 
+                    {
                         "name": "About",
                         "type": "Microsoft.Common.InfoBox",
                         "options": {
@@ -1292,6 +1313,7 @@
             "numberOfInstances": "[int(basics('basicsRequired').numberOfInstances)]",
             "portsToExpose": "[basics('basicsOptional').portsToExpose]",
             "skuUrnVersion": "[basics('skuUrnVersion')]",
+            "useSystemAssignedManagedIdentity": "[basics('basicsOptional').useSystemAssignedManagedIdentity]",
             "vmSizeSelect": "[basics('vmSizeSelect')]",
             "vmSizeSelectForCoherence": "[steps('section_coherence').coherenceInfo.coherenceVMSizeSelect]",
             "wlsDomainName": "[basics('basicsOptional').wlsDomainName]",

--- a/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
@@ -381,6 +381,13 @@
                 "description": "Bool value, if it's set to true, will deploy with preview weblogic image."
             }
         },
+        "useSystemAssignedManagedIdentity": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Bool value, if it's set to true, a system assigned managed identity will to be created for the VM(s)"
+            }
+        },
         "vmSizeSelect": {
             "defaultValue": "Standard_A3",
             "type": "string",
@@ -539,6 +546,9 @@
                     },
                     "usePreviewImage": {
                         "value": "[parameters('usePreviewImage')]"
+                    },
+                    "useSystemAssignedManagedIdentity": {
+                        "value": "[parameters('useSystemAssignedManagedIdentity')]"
                     },
                     "vmSizeSelect": {
                         "value": "[parameters('vmSizeSelect')]"

--- a/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/clusterTemplate.json
@@ -113,6 +113,13 @@
                 "description": "Bool value, if it's set to true, will deploy with preview weblogic image."
             }
         },
+        "useSystemAssignedManagedIdentity": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "Bool value, if it's set to true, a system assigned managed identity will to be created for the VM(s)"
+            }
+        },
         "vmSizeSelect": {
             "type": "string",
             "defaultValue": "Standard_A3",
@@ -423,6 +430,7 @@
                 "nicLoop",
                 "[resourceId('Microsoft.Compute/availabilitySets/', variables('name_availabilitySet'))]"
             ],
+            "identity": "[if(parameters('useSystemAssignedManagedIdentity'), json('{\"type\":\"SystemAssigned\"}'), null())]",
             "properties": {
                 "availabilitySet": {
                     "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('name_availabilitySet'))]"

--- a/test/scripts/gen-parameters-deploy-elk.sh
+++ b/test/scripts/gen-parameters-deploy-elk.sh
@@ -14,6 +14,7 @@ wlspassword=${10}
 gitUserName=${11}
 testbranchName=${12}
 managedServerPrefix=${13}
+guidValue=${14}
 
 numberOfInstances=$((numberOfInstances-1))
 
@@ -30,6 +31,9 @@ cat <<EOF > ${parametersPath}
       },
       "elasticsearchUserName": {
         "value": "${elasticsearchUserName}"
+      },
+      "guidValue": {
+        "value": "${guidValue}"
       },
       "location": {
         "value": "${location}"


### PR DESCRIPTION
Add system assigned managed identity for vm
-- Add option group in UI to let users choose if they want to add the identity.
-- Update mainTemplate and clusterTemplate to adopt users' choice.

Add ELK index clean up step in the workflow
-- Update build.yml to pass guidValue for generating ELK index so the index can be used later at the added cleaning step.
-- Update gen-parameters-deploy-elk.sh to adopt passed guidValue.
