### PR TITLE
Disable AZ resources deployment for schedule trigger on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,7 @@ jobs:
           path: ${{steps.addnode_coherence_artifact_file.outputs.addnode_coherence_artifactPath}}
 
   deploy-dependencies:
+    if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
     needs: preflight
     runs-on: ubuntu-latest
     steps:
@@ -215,6 +216,7 @@ jobs:
             --end-ip-address "0.0.0.0"
 
   deploy-weblogic-cluster:
+    if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
     needs: deploy-dependencies
     runs-on: ubuntu-latest
     strategy:
@@ -905,7 +907,7 @@ jobs:
         run: |
           curl -XDELETE --user ${{ env.elkUser }}:${{ env.elkPassword }}  ${{ env.elkURI }}/azure-weblogic-cluster-${{ github.run_id }}${{ github.run_number }}
 
-  cleanup:
+  cleanup-github-resoruce:
     needs: deploy-weblogic-cluster
     if: always()
     runs-on: ubuntu-latest
@@ -919,6 +921,11 @@ jobs:
           cd ${{ env.repoName }}
           git push https://$gitToken@github.com/$userName/${{ env.repoName }}.git -f --delete $testbranchName
 
+  cleanup-az-resource:
+    if: ${{!(github.event_name == 'schedule' && github.repository_owner != 'wls-eng')}}
+    needs: deploy-weblogic-cluster
+    runs-on: ubuntu-latest
+    steps:
       - uses: azure/login@v1
         id: azure-login
         with:


### PR DESCRIPTION
If the pipeline is triggered by schedule events in fork repos, do not deploy WLS instance.