### PR TITLE
Bug fixed and enhancement

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -413,6 +413,16 @@
                         "label": "TLS/SSL Configuration Settings",
                         "elements": [
                             {
+                                "name": "sslKeystoreInfo0",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "true",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "It's not allowed to use the same keystore for identity and trust. Click the link for how to obtain and store certificates for development and production environments.",
+                                    "uri": "https://aka.ms/arm-oraclelinux-wls-ssl-configuration"
+                                }
+                            },
+                            {
                                 "name": "uploadedCustomIdentityKeyStoreData",
                                 "type": "Microsoft.Common.FileUpload",
                                 "label": "Custom Identity KeyStore Data file(.jks,.p12)",
@@ -561,6 +571,16 @@
                         "visible": "[and(steps('section_sslConfiguration').enableCustomSSL, equals(steps('section_sslConfiguration').sslConfigurationAccessOption, 'keyVaultStoredConfig'))]",
 						"label": "TLS/SSL Configuration Settings",
 						"elements": [
+                            {
+                                "name": "sslKeystoreInfo1",
+                                "type": "Microsoft.Common.InfoBox",
+                                "visible": "true",
+                                "options": {
+                                    "icon": "Info",
+                                    "text": "It's not allowed to use the same keystore for identity and trust. Click the link for how to obtain and store certificates for development and production environments.",
+                                    "uri": "https://aka.ms/arm-oraclelinux-wls-ssl-configuration"
+                                }
+                            },
                             {
                                 "name": "keyVaultText",
                                 "type": "Microsoft.Common.TextBlock",

--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -964,7 +964,7 @@
                         "type": "Microsoft.Common.TextBlock",
                         "visible": true,
                         "options": {
-                            "text": "Selecting 'Yes' here will cause the template to provision Application Gateway using a custom DNS Name (for example: console.contoso.com)",
+                            "text": "Selecting 'Yes' here will cause the template to provision Oracle WebLogic Server Administration Console and Application Gateway using a custom DNS Name (for example: applications.contoso.com)",
                             "link": {
                                 "label": "Learn more",
                                 "uri": "https://aka.ms/arm-oraclelinux-wls-dns"
@@ -1067,7 +1067,7 @@
                                 "name": "dnszoneAdminConsoleLabel",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "Label for Oracle WebLogic Administration Console",
-                                "defaultValue": "console",
+                                "defaultValue": "admin",
                                 "toolTip": "Specify a label to generate subdomain of Oracle WebLogic Administration Console",
                                 "constraints": {
                                     "required": true,
@@ -1078,7 +1078,7 @@
                                         },
                                         {
                                             "isValid": "[less(sub(length(concat(steps('section_dnsConfiguration').customDNSSettings.dnszoneAdminConsoleLabel,'.',steps('section_dnsConfiguration').customDNSSettings.dnszoneName)),length(replace(concat(steps('section_dnsConfiguration').customDNSSettings.dnszoneAdminConsoleLabel,'.',steps('section_dnsConfiguration').customDNSSettings.dnszoneName), '.', ''))),34)]",
-                                            "message": "Subdomain must be between 2 and 34 labels. For example, \"applications.contoso.com\" has 3 labels."
+                                            "message": "Subdomain must be between 2 and 34 labels. For example, \"admin.contoso.com\" has 3 labels."
                                         }
                                     ]
                                 }

--- a/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/mainTemplate.json
@@ -264,6 +264,10 @@
                 "description": "Public IP Name for the Application Gateway"
             }
         },
+        "guidValue": {
+			"type": "string",
+			"defaultValue": "[newGuid()]"
+		},
         "hasDNSZones": {
             "type": "bool",
             "defaultValue": false,
@@ -637,7 +641,7 @@
         "const_sslConfigurationAccessOptionUploadConfig": "uploadConfig",
         "const_sslConfigurationAccessOptionKeyVaultStoredConfig": "keyVaultStoredConfig",
         "const_azureSubjectName": "[format('{0}.{1}.{2}', variables('name_domainLabelforApplicationGateway'), parameters('location'),'.cloudapp.azure.com')]",
-        "const_guidValue": "[guid(resourceGroup().id, deployment().name)]",
+        "const_guidValue": "[parameters('guidValue')]",
         "name_aadLinkedTemplateName": "aadNestedTemplate.json",
         "name_appGatewayConnector": "_keyvaultAppGatewayConnectorTemplate.json",
         "name_clusterLinkedTemplateName": "clusterTemplate.json",
@@ -646,7 +650,7 @@
         "name_dbLinkedTemplateName": "dbTemplate.json",
         "name_dnsNameforApplicationGateway": "[concat(parameters('dnsNameforApplicationGateway'), take(replace(variables('const_guidValue'),'-',''),6))]",
         "name_dnszonesLinkedTemplateName": "dnszonesTemplate.json",
-        "name_domainLabelforApplicationGateway": "[concat(variables('name_dnsNameforApplicationGateway'),'-',toLower(resourceGroup().name),'-',toLower(parameters('wlsDomainName')))]",
+        "name_domainLabelforApplicationGateway": "[take(concat(variables('name_dnsNameforApplicationGateway'),'-',toLower(resourceGroup().name),'-',toLower(parameters('wlsDomainName'))),63)]",
         "name_elkLinkedTemplateName": "elkNestedTemplate.json",
         "name_keyVaultLinkedTemplateName": "_keyvaultAdapterTemplate.json",
         "name_nsgLinkedTemplateName": "nsgNestedTemplate.json",

--- a/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/appGatewayNestedTemplate.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/nestedtemplates/appGatewayNestedTemplate.json
@@ -43,7 +43,7 @@
 			}
 		},
 		"dnsNameforApplicationGateway": {
-			"defaultValue": "[format('{0}{1}-{2}-{3}', 'wlsgw',take(replace(parameters('guidValue'),'-',''),6), toLower(resourceGroup().name),toLower(parameters('wlsDomainName')))]",
+			"defaultValue": "[take(format('{0}{1}-{2}-{3}', 'wlsgw',take(replace(parameters('guidValue'),'-',''),6), toLower(resourceGroup().name),toLower(parameters('wlsDomainName'))),63)]",
 			"type": "string",
 			"metadata": {
 				"description": "DNS for ApplicationGateway"

--- a/arm-oraclelinux-wls-cluster/src/main/scripts/elkIntegration.sh
+++ b/arm-oraclelinux-wls-cluster/src/main/scripts/elkIntegration.sh
@@ -683,7 +683,7 @@ function create_temp_folder()
 function validate_elastic_server()
 {
     timestamp=$(date +%s)
-    testIndex="azure-weblogic-validate-elastic-server-${timestamp}"
+    testIndex="${logIndex}-validate-elk-server-from-server-${index}-${timestamp}"
     output=$(curl -XPUT --user ${elasticUserName}:${elasticPassword}  ${elasticURI}/${testIndex})
     if [[ $? -eq 1 ||  -z `echo $output | grep "\"acknowledged\":true"` ]];then
         echo $output


### PR DESCRIPTION
Fix [DNS redirecting issue to admin console](https://github.com/wls-eng/arm-oraclelinux-wls/issues/282)
Fix [ELK deployment failed with creating index conflict](https://github.com/wls-eng/arm-oraclelinux-wls/issues/281)
Fix [Add UI notification for "can not share the same keystore for Identity and Trust" in TSL/SSL blade](https://github.com/wls-eng/arm-oraclelinux-wls/issues/283)
Fix [KeyVaultAppGatewayTemplate fails to deploy if the resource group name is very long](https://github.com/wls-eng/arm-oraclelinux-wls/issues/276)

ELK test index:

- Index to validate the elk server is accessible
- To make the index unique, use combination of `${logIndex}-validate-elk-server-from-server-${index}-${timestamp}`
  - logIndex is unique for every deployment.
  - index is server index, admin server index is 0, managed server index is 1-N
  - timestamp timestamp of validating the elk server.
 