### PR TITLE
Update texts and default values

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -1051,12 +1051,9 @@
                                 "name": "deplymentScriptInfo",
                                 "type": "Microsoft.Common.TextBlock",
                                 "options": {
-                                    "text": "Bring Azure DNS Zone option will add records to your DNS Zone to cause Oracle WebLogic Server Administration Console and Application Gateway accessible via DNS alias. We need a user-assigned managed identity to update your resource group that has Azure DNS Zone deployed. ",
-                                    "link": {
-                                        "label": "Learn more",
-                                        "uri": "https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deployment-script-template"
-                                    }
-                                }
+                                    "text": "If you choose to use an existing Azure DNS Zone, you must select a user-assigned managed identity to enable the necessary configuration."
+                                },
+                                "visible": "[steps('section_dnsConfiguration').customDNSSettings.bringDNSZone]"
                             },
                             {
                                 "name": "dnszoneName",
@@ -1107,7 +1104,7 @@
                                 "name": "dnszoneGatewayLabel",
                                 "type": "Microsoft.Common.TextBox",
                                 "label": "Label for Application Gateway",
-                                "defaultValue": "applications",
+                                "defaultValue": "www",
                                 "toolTip": "Specify a label to generate subdomain of Application Gateway",
                                 "constraints": {
                                     "required": true,


### PR DESCRIPTION
On DNS Configuration blade, update the text's visibility, words, and remove 'learn more' link
Change default value for "Label for Application Gateway" to be "www"