### PR TITLE
On branch gh-300-keystore-type-fix-tooltip

### DIFF
--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -462,7 +462,7 @@
                                 "visible": "true",
                                 "label": "The Identity KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -548,7 +548,7 @@
                                 "visible": "true",
                                 "label": "The Trust KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [
                                         {
@@ -651,7 +651,7 @@
                                 "visible": "true",
                                 "label": "The Identity KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [{
                                             "label": "JKS",
@@ -723,7 +723,7 @@
                                 "visible": "true",
                                 "label": "The Trust KeyStore type (JKS,PKCS12)",
                                 "defaultValue": "JKS",
-                                "toolTip": "Use only letters and numbers",
+                                "toolTip": "One of the supported KeyStore types",
                                 "constraints": {
                                     "allowedValues": [{
                                             "label": "JKS",


### PR DESCRIPTION
https://github.com/wls-eng/arm-oraclelinux-wls/issues/300

modified:   arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json

- Replace "Use only letters and numbers" with "One of the supported KeyStore types" in the context of the KeyStore type dropdown.

Signed-off-by: Ed Burns <edburns@microsoft.com>